### PR TITLE
Removing callbackGraph entry from the wsman inventory service payload

### DIFF
--- a/lib/jobs/dell-wsman-inventory.js
+++ b/lib/jobs/dell-wsman-inventory.js
@@ -152,7 +152,6 @@ function DellWsmanInventoryJobFactory(BaseJob, Logger, Promise, util, waterline,
       	var request = {
   			credential: self.target,
   			callbackUri: callback,
-  			callbackGraph: 'Graph.Dell.Wsman.InventoryCallback',
   			type: type
   		}
 


### PR DESCRIPTION
callbackGraph was used on original callback implementation which went through northbound api.