### PR TITLE
Fixed dell-wsman-update-systemcomponents.js to support updating credentials

### DIFF
--- a/lib/jobs/dell-wsman-update-systemcomponents.js
+++ b/lib/jobs/dell-wsman-update-systemcomponents.js
@@ -18,6 +18,7 @@ di.annotate(DellWsmanUpdateSystemConfigComponentsFactory, new di.Inject(
     '_',
     'HttpTool',
     'Errors',
+    'Services.Encryption',
     'validator'
 ));
 
@@ -32,6 +33,7 @@ function DellWsmanUpdateSystemConfigComponentsFactory(
     _,
     HttpTool,
     errors,
+    encryption,
     validator
 ) {
     var logger = Logger.initialize(DellWsmanUpdateSystemConfigComponentsFactory);
@@ -53,8 +55,8 @@ function DellWsmanUpdateSystemConfigComponentsFactory(
         }
 
         return Promise.resolve(self.checkOBM())
-            .then(function(){
-                return self.updateComponents();
+            .then(function(obm){
+                return self.updateComponents(obm);
             })
             .then(function(){
                 return self._done();
@@ -80,10 +82,11 @@ function DellWsmanUpdateSystemConfigComponentsFactory(
                 if (!obm) {
                     throw new errors.NotFoundError('Cannot find WSMAN OBM settings');
                 }
+                return obm;
             })
     };
 
-    DellWsmanUpdateSystemConfigComponentsJob.prototype.updateComponents = function() {
+    DellWsmanUpdateSystemConfigComponentsJob.prototype.updateComponents = function(obm) {
 
         if (!validator.isIP(this.options.serverIP) || !validator.isIP(this.options.shareAddress)) {
             throw new Error('Invalid ServerIP/ShareAddress');
@@ -94,8 +97,8 @@ function DellWsmanUpdateSystemConfigComponentsFactory(
             "serverAndNetworkShareRequest": {
                 "fileName": this.options.fileName,
                 "serverIP": this.options.serverIP,
-                "serverPassword": this.options.serverPassword,
-                "serverUsername": this.options.serverUsername,
+                "serverUsername": obm.config.userName,
+                "serverPassword": encryption.decrypt(obm.config.password),
                 "shareAddress": this.options.shareAddress,
                 "shareName": this.options.shareName,
                 "shareType": this.options.shareType,


### PR DESCRIPTION
Fixed dell-wsman-update-systemcomponents.js to support updating credentials from the obm block before submitting the microservice request.

@phelpdh @rahmanmuhamad 

This approach works well.  Take a look and see if you agree.  Thanks.  Other systemcomponents calls may need the same treatment.